### PR TITLE
Fix PWA icon paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
   <!-- Manifest (cache-busted so iOS A2HS sticks to /eq-teaching-tracker/) -->
   <link rel="manifest" href="manifest.webmanifest?v=3">
-  <link rel="apple-touch-icon" href="./icons/icon-192.png">
+  <link rel="apple-touch-icon" href="./icon-192.png">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <!-- Added for Chrome/Android PWA notice -->
   <meta name="mobile-web-app-capable" content="yes">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -7,7 +7,7 @@
   "background_color": "#f7f9fc",
   "theme_color": "#145AFF",
   "icons": [
-    { "src": "./icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "./icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "./icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "./icon-512.png", "sizes": "512x512", "type": "image/png" }
   ]
 }


### PR DESCRIPTION
## Summary
- point the apple-touch-icon link in index.html at the real icon file in the project root
- update manifest.webmanifest to reference the existing 192px and 512px PNG icons directly

## Testing
- not run (static asset path fix)


------
https://chatgpt.com/codex/tasks/task_e_68cc82f82abc8326a6b05c01afbe110d