### PR TITLE
Stack tools cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,10 @@
     section{display:none}
     section.active{display:block}
     .row{display:flex;gap:12px;flex-wrap:wrap}
+    @media (max-width: 600px) {
+      .tools .row{flex-direction:column}
+      .tools .card{flex:1 1 100%;width:100%}
+    }
     .card{background:var(--card);border:1px solid #e5e8ef;border-radius:14px;padding:12px}
     .card h3{margin:0 0 6px 0;font-size:16px}
     .muted{color:var(--muted);font-size:12px}


### PR DESCRIPTION
## Summary
- add a mobile breakpoint that stacks the tools row vertically
- ensure each tools card spans the full width on small screens

## Testing
- python3 -m http.server 8000 (manual mobile viewport verification)


------
https://chatgpt.com/codex/tasks/task_e_68cd8259426c83269dec541fe7eea89f