### PR TITLE
Increase button touch targets

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     .wrap{max-width:1024px;margin:0 auto;padding:16px}
     h1{font-size:20px;margin:0}
     nav{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
-    nav button{border:1px solid #e5e8ef;background:#fff;border-radius:12px;padding:8px 12px;cursor:pointer}
+    nav button{border:1px solid #e5e8ef;background:#fff;border-radius:12px;padding:10px 16px;cursor:pointer;min-height:44px;line-height:1.3;display:inline-flex;align-items:center;justify-content:center}
     nav button.active{background:var(--accent);border-color:var(--accent);color:#fff}
     main{padding-bottom:64px}
     section{display:none}
@@ -33,7 +33,7 @@
     .card{background:var(--card);border:1px solid #e5e8ef;border-radius:14px;padding:12px}
     .card h3{margin:0 0 6px 0;font-size:16px}
     .muted{color:var(--muted);font-size:12px}
-    .btn{display:inline-flex;align-items:center;gap:6px;padding:8px 10px;border-radius:10px;border:1px solid #ccd3e0;background:#fff;cursor:pointer}
+    .btn{display:inline-flex;align-items:center;gap:6px;padding:10px 12px;border-radius:10px;border:1px solid #ccd3e0;background:#fff;cursor:pointer;min-height:44px;line-height:1.3}
     .btn.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
     .btn.danger{border-color:var(--red);color:#d44545;background:#fff}
     input,select,textarea{font-size:16px;padding:8px;border:1px solid #ccd3e0;border-radius:10px;background:#fff; touch-action:manipulation;}


### PR DESCRIPTION
## Summary
- expand nav buttons with larger padding and a 44px minimum height for better touch targets
- increase `.btn` controls to match the accessible minimum height while keeping existing variants intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd8268b874832693f69ced56ebb2cb